### PR TITLE
Updated syntax for rebind statement based on latest VS version compil…

### DIFF
--- a/include/RE/GList.h
+++ b/include/RE/GList.h
@@ -45,7 +45,7 @@ namespace RE
 		using reference = value_type&;
 		using const_reference = const value_type&;
 		using pointer = value_type*;
-		using const_pointer = std::pointer_traits<pointer>::rebind<const value_type>;
+		using const_pointer = typename std::pointer_traits<pointer>::template rebind<const value_type>;
 
 
 		template <class U>


### PR DESCRIPTION
Latest visual studio update complained about syntax error on changed line.   Checked with most up to date CommonLib SSE and just copied the updated syntax from there.   This compiles with latest VS.